### PR TITLE
RTC module

### DIFF
--- a/newine_server_init
+++ b/newine_server_init
@@ -11,4 +11,7 @@ chmod a+rw /dev/i2c-1
 daemon --chdir=/app --output=/app/thin.log -- /usr/bin/ruby run.rb
 daemon --respawn --chdir=/app --output=/app/nfc.log -- /usr/bin/rake2.1 nfc:work
 
+#Sets time from external RTC module if no internet connection is present
+bash rtc
+
 while true; do sleep 1; done

--- a/rtc
+++ b/rtc
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+PING="/bin/ping -q -c1"
+HOST=www.google.com
+
+echo "Including new RTC device in i2c-adapter"
+echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-1/new_device
+
+echo "Setting Time Zone"
+rm /etc/localtime
+ln -s /usr/share/zoneinfo/America/Buenos_Aires /etc/localtime
+hwclock --localtime -f /dev/rtc1
+
+echo "Checking Internet connection"
+${PING} ${HOST}
+if [ $? -ne 0 ]; then
+   	echo "No internet connection - Current time will be set from external RTC"
+	hwclock -w -f /dev/rtc1	
+
+else
+	echo "There is internet connection - Current time will be stored in external RTC"
+       	hwclock --systohc -f /dev/rtc1
+fi


### PR DESCRIPTION
Agrego script para el modulo RTC (Real Time Clock) externo (placa azul
montada sobre la beagle)
Si hay coneccion a internet se guarda la hora en el modulo RTC
Si no hay internet se recupera la hora del modulo RTC para setear la
beagle
Esto es necesario ya que la beagle no guarda la hora por si misma cuando
se apaga.